### PR TITLE
Rename to NGINX terms

### DIFF
--- a/internal/application/application_constants.go
+++ b/internal/application/application_constants.go
@@ -20,9 +20,9 @@ package application
 // 3. Update the NewBorderClient factory method in border_client.go that returns the client;
 const (
 
-	// ClientTypeTcp creates a TcpBorderClient that uses the Stream* methods of the NGINX Plus client.
-	ClientTypeTcp = "tcp"
+	// ClientTypeNginxStream creates a NginxStreamBorderClient that uses the Stream* methods of the NGINX Plus client.
+	ClientTypeNginxStream = "stream"
 
-	// ClientTypeHttp creates an HttpBorderClient that uses the HTTP* methods of the NGINX Plus client.
-	ClientTypeHttp = "http"
+	// ClientTypeNginxHttp creates an NginxHttpBorderClient that uses the HTTP* methods of the NGINX Plus client.
+	ClientTypeNginxHttp = "http"
 )

--- a/internal/application/border_client.go
+++ b/internal/application/border_client.go
@@ -31,11 +31,11 @@ func NewBorderClient(clientType string, borderClient interface{}) (Interface, er
 	logrus.Debugf(`NewBorderClient for type: %s`, clientType)
 
 	switch clientType {
-	case ClientTypeTcp:
-		return NewTcpBorderClient(borderClient)
+	case ClientTypeNginxStream:
+		return NewNginxStreamBorderClient(borderClient)
 
-	case ClientTypeHttp:
-		return NewHttpBorderClient(borderClient)
+	case ClientTypeNginxHttp:
+		return NewNginxHttpBorderClient(borderClient)
 
 	default:
 		borderClient, _ := NewNullBorderClient()

--- a/internal/application/border_client_test.go
+++ b/internal/application/border_client_test.go
@@ -17,20 +17,20 @@ func TestBorderClient_CreatesHttpBorderClient(t *testing.T) {
 		t.Errorf(`error creating border client: %v`, err)
 	}
 
-	if _, ok := client.(*HttpBorderClient); !ok {
-		t.Errorf(`expected client to be of type HttpBorderClient`)
+	if _, ok := client.(*NginxHttpBorderClient); !ok {
+		t.Errorf(`expected client to be of type NginxHttpBorderClient`)
 	}
 }
 
 func TestBorderClient_CreatesTcpBorderClient(t *testing.T) {
 	borderClient := mocks.MockNginxClient{}
-	client, err := NewBorderClient("tcp", borderClient)
+	client, err := NewBorderClient("stream", borderClient)
 	if err != nil {
 		t.Errorf(`error creating border client: %v`, err)
 	}
 
-	if _, ok := client.(*TcpBorderClient); !ok {
-		t.Errorf(`expected client to be of type TcpBorderClient`)
+	if _, ok := client.(*NginxStreamBorderClient); !ok {
+		t.Errorf(`expected client to be of type NginxStreamBorderClient`)
 	}
 }
 

--- a/internal/application/doc.go
+++ b/internal/application/doc.go
@@ -17,8 +17,8 @@ To add a Border Server client...
 At this time the only supported Border Servers are NGINX Plus servers.
 
 The two Border Server clients for NGINX Plus are:
-- HttpBorderClient: updates NGINX Plus servers using HTTP Upstream methods on the NGINX Plus API.
-- TcpBorderClient: updates NGINX Plus servers using Stream Upstream methods on the NGINX Plus API.
+- NginxHttpBorderClient: updates NGINX Plus servers using HTTP Upstream methods on the NGINX Plus API.
+- NginxStreamBorderClient: updates NGINX Plus servers using Stream Upstream methods on the NGINX Plus API.
 
 Both of these implementations use the NGINX Plus client module to communicate with the NGINX Plus server.
 

--- a/internal/application/nginx_client_interface.go
+++ b/internal/application/nginx_client_interface.go
@@ -9,15 +9,15 @@ import nginxClient "github.com/nginxinc/nginx-plus-go-client/client"
 
 // NginxClientInterface defines the functions used on the NGINX Plus client, abstracting away the full details of that client.
 type NginxClientInterface interface {
-	// DeleteStreamServer is used by the TcpBorderClient.
+	// DeleteStreamServer is used by the NginxStreamBorderClient.
 	DeleteStreamServer(upstream string, server string) error
 
-	// UpdateStreamServers is used by the TcpBorderClient.
+	// UpdateStreamServers is used by the NginxStreamBorderClient.
 	UpdateStreamServers(upstream string, servers []nginxClient.StreamUpstreamServer) ([]nginxClient.StreamUpstreamServer, []nginxClient.StreamUpstreamServer, []nginxClient.StreamUpstreamServer, error)
 
-	// DeleteHTTPServer is used by the HttpBorderClient.
+	// DeleteHTTPServer is used by the NginxHttpBorderClient.
 	DeleteHTTPServer(upstream string, server string) error
 
-	// UpdateHTTPServers is used by the HttpBorderClient.
+	// UpdateHTTPServers is used by the NginxHttpBorderClient.
 	UpdateHTTPServers(upstream string, servers []nginxClient.UpstreamServer) ([]nginxClient.UpstreamServer, []nginxClient.UpstreamServer, []nginxClient.UpstreamServer, error)
 }

--- a/internal/application/nginx_http_border_client.go
+++ b/internal/application/nginx_http_border_client.go
@@ -11,26 +11,26 @@ import (
 	nginxClient "github.com/nginxinc/nginx-plus-go-client/client"
 )
 
-// HttpBorderClient implements the BorderClient interface for HTTP upstreams.
-type HttpBorderClient struct {
+// NginxHttpBorderClient implements the BorderClient interface for HTTP upstreams.
+type NginxHttpBorderClient struct {
 	BorderClient
 	nginxClient NginxClientInterface
 }
 
-// NewHttpBorderClient is the Factory function for creating an HttpBorderClient.
-func NewHttpBorderClient(client interface{}) (Interface, error) {
+// NewNginxHttpBorderClient is the Factory function for creating an NginxHttpBorderClient.
+func NewNginxHttpBorderClient(client interface{}) (Interface, error) {
 	ngxClient, ok := client.(NginxClientInterface)
 	if !ok {
 		return nil, fmt.Errorf(`expected a NginxClientInterface, got a %v`, client)
 	}
 
-	return &HttpBorderClient{
+	return &NginxHttpBorderClient{
 		nginxClient: ngxClient,
 	}, nil
 }
 
 // Update manages the Upstream servers for the Upstream Name given in the ServerUpdateEvent.
-func (hbc *HttpBorderClient) Update(event *core.ServerUpdateEvent) error {
+func (hbc *NginxHttpBorderClient) Update(event *core.ServerUpdateEvent) error {
 	httpUpstreamServers := asNginxHttpUpstreamServers(event.UpstreamServers)
 	_, _, _, err := hbc.nginxClient.UpdateHTTPServers(event.UpstreamName, httpUpstreamServers)
 	if err != nil {
@@ -41,7 +41,7 @@ func (hbc *HttpBorderClient) Update(event *core.ServerUpdateEvent) error {
 }
 
 // Delete deletes the Upstream server for the Upstream Name given in the ServerUpdateEvent.
-func (hbc *HttpBorderClient) Delete(event *core.ServerUpdateEvent) error {
+func (hbc *NginxHttpBorderClient) Delete(event *core.ServerUpdateEvent) error {
 	err := hbc.nginxClient.DeleteHTTPServer(event.UpstreamName, event.UpstreamServers[0].Host)
 	if err != nil {
 		return fmt.Errorf(`error occurred deleting the nginx+ upstream server: %w`, err)

--- a/internal/application/nginx_http_border_client_test.go
+++ b/internal/application/nginx_http_border_client_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 )
 
-func TestTcpBorderClient_Delete(t *testing.T) {
-	event := buildServerUpdateEvent(deletedEventType, ClientTypeTcp)
-	borderClient, nginxClient, err := buildBorderClient(ClientTypeTcp)
+func TestHttpBorderClient_Delete(t *testing.T) {
+	event := buildServerUpdateEvent(deletedEventType, ClientTypeNginxHttp)
+	borderClient, nginxClient, err := buildBorderClient(ClientTypeNginxHttp)
 	if err != nil {
 		t.Fatalf(`error occurred creating a new border client: %v`, err)
 	}
@@ -21,14 +21,14 @@ func TestTcpBorderClient_Delete(t *testing.T) {
 		t.Fatalf(`error occurred deleting the nginx+ upstream server: %v`, err)
 	}
 
-	if !nginxClient.CalledFunctions["DeleteStreamServer"] {
-		t.Fatalf(`expected DeleteStreamServer to be called`)
+	if !nginxClient.CalledFunctions["DeleteHTTPServer"] {
+		t.Fatalf(`expected DeleteHTTPServer to be called`)
 	}
 }
 
-func TestTcpBorderClient_Update(t *testing.T) {
-	event := buildServerUpdateEvent(createEventType, ClientTypeTcp)
-	borderClient, nginxClient, err := buildBorderClient(ClientTypeTcp)
+func TestHttpBorderClient_Update(t *testing.T) {
+	event := buildServerUpdateEvent(createEventType, ClientTypeNginxHttp)
+	borderClient, nginxClient, err := buildBorderClient(ClientTypeNginxHttp)
 	if err != nil {
 		t.Fatalf(`error occurred creating a new border client: %v`, err)
 	}
@@ -38,22 +38,22 @@ func TestTcpBorderClient_Update(t *testing.T) {
 		t.Fatalf(`error occurred deleting the nginx+ upstream server: %v`, err)
 	}
 
-	if !nginxClient.CalledFunctions["UpdateStreamServers"] {
-		t.Fatalf(`expected UpdateStreamServers to be called`)
+	if !nginxClient.CalledFunctions["UpdateHTTPServers"] {
+		t.Fatalf(`expected UpdateHTTPServers to be called`)
 	}
 }
 
-func TestTcpBorderClient_BadNginxClient(t *testing.T) {
+func TestHttpBorderClient_BadNginxClient(t *testing.T) {
 	var emptyInterface interface{}
-	_, err := NewBorderClient(ClientTypeTcp, emptyInterface)
+	_, err := NewBorderClient(ClientTypeNginxHttp, emptyInterface)
 	if err == nil {
 		t.Fatalf(`expected an error to occur when creating a new border client`)
 	}
 }
 
-func TestTcpBorderClient_DeleteReturnsError(t *testing.T) {
-	event := buildServerUpdateEvent(deletedEventType, ClientTypeTcp)
-	borderClient, _, err := buildTerrorizingBorderClient(ClientTypeTcp)
+func TestHttpBorderClient_DeleteReturnsError(t *testing.T) {
+	event := buildServerUpdateEvent(deletedEventType, ClientTypeNginxHttp)
+	borderClient, _, err := buildTerrorizingBorderClient(ClientTypeNginxHttp)
 	if err != nil {
 		t.Fatalf(`error occurred creating a new border client: %v`, err)
 	}
@@ -65,9 +65,9 @@ func TestTcpBorderClient_DeleteReturnsError(t *testing.T) {
 	}
 }
 
-func TestTcpBorderClient_UpdateReturnsError(t *testing.T) {
-	event := buildServerUpdateEvent(createEventType, ClientTypeTcp)
-	borderClient, _, err := buildTerrorizingBorderClient(ClientTypeTcp)
+func TestHttpBorderClient_UpdateReturnsError(t *testing.T) {
+	event := buildServerUpdateEvent(createEventType, ClientTypeNginxHttp)
+	borderClient, _, err := buildTerrorizingBorderClient(ClientTypeNginxHttp)
 	if err != nil {
 		t.Fatalf(`error occurred creating a new border client: %v`, err)
 	}

--- a/internal/application/nginx_stream_border_client.go
+++ b/internal/application/nginx_stream_border_client.go
@@ -11,26 +11,26 @@ import (
 	nginxClient "github.com/nginxinc/nginx-plus-go-client/client"
 )
 
-// TcpBorderClient implements the BorderClient interface for TCP upstreams.
-type TcpBorderClient struct {
+// NginxStreamBorderClient implements the BorderClient interface for stream upstreams.
+type NginxStreamBorderClient struct {
 	BorderClient
 	nginxClient NginxClientInterface
 }
 
-// NewTcpBorderClient is the Factory function for creating an TcpBorderClient.
-func NewTcpBorderClient(client interface{}) (Interface, error) {
+// NewNginxStreamBorderClient is the Factory function for creating an NginxStreamBorderClient.
+func NewNginxStreamBorderClient(client interface{}) (Interface, error) {
 	ngxClient, ok := client.(NginxClientInterface)
 	if !ok {
 		return nil, fmt.Errorf(`expected a NginxClientInterface, got a %v`, client)
 	}
 
-	return &TcpBorderClient{
+	return &NginxStreamBorderClient{
 		nginxClient: ngxClient,
 	}, nil
 }
 
 // Update manages the Upstream servers for the Upstream Name given in the ServerUpdateEvent.
-func (tbc *TcpBorderClient) Update(event *core.ServerUpdateEvent) error {
+func (tbc *NginxStreamBorderClient) Update(event *core.ServerUpdateEvent) error {
 	streamUpstreamServers := asNginxStreamUpstreamServers(event.UpstreamServers)
 	_, _, _, err := tbc.nginxClient.UpdateStreamServers(event.UpstreamName, streamUpstreamServers)
 	if err != nil {
@@ -41,7 +41,7 @@ func (tbc *TcpBorderClient) Update(event *core.ServerUpdateEvent) error {
 }
 
 // Delete deletes the Upstream server for the Upstream Name given in the ServerUpdateEvent.
-func (tbc *TcpBorderClient) Delete(event *core.ServerUpdateEvent) error {
+func (tbc *NginxStreamBorderClient) Delete(event *core.ServerUpdateEvent) error {
 	err := tbc.nginxClient.DeleteStreamServer(event.UpstreamName, event.UpstreamServers[0].Host)
 	if err != nil {
 		return fmt.Errorf(`error occurred deleting the nginx+ upstream server: %w`, err)

--- a/internal/application/nginx_stream_border_client_test.go
+++ b/internal/application/nginx_stream_border_client_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 )
 
-func TestHttpBorderClient_Delete(t *testing.T) {
-	event := buildServerUpdateEvent(deletedEventType, ClientTypeHttp)
-	borderClient, nginxClient, err := buildBorderClient(ClientTypeHttp)
+func TestTcpBorderClient_Delete(t *testing.T) {
+	event := buildServerUpdateEvent(deletedEventType, ClientTypeNginxStream)
+	borderClient, nginxClient, err := buildBorderClient(ClientTypeNginxStream)
 	if err != nil {
 		t.Fatalf(`error occurred creating a new border client: %v`, err)
 	}
@@ -21,14 +21,14 @@ func TestHttpBorderClient_Delete(t *testing.T) {
 		t.Fatalf(`error occurred deleting the nginx+ upstream server: %v`, err)
 	}
 
-	if !nginxClient.CalledFunctions["DeleteHTTPServer"] {
-		t.Fatalf(`expected DeleteHTTPServer to be called`)
+	if !nginxClient.CalledFunctions["DeleteStreamServer"] {
+		t.Fatalf(`expected DeleteStreamServer to be called`)
 	}
 }
 
-func TestHttpBorderClient_Update(t *testing.T) {
-	event := buildServerUpdateEvent(createEventType, ClientTypeHttp)
-	borderClient, nginxClient, err := buildBorderClient(ClientTypeHttp)
+func TestTcpBorderClient_Update(t *testing.T) {
+	event := buildServerUpdateEvent(createEventType, ClientTypeNginxStream)
+	borderClient, nginxClient, err := buildBorderClient(ClientTypeNginxStream)
 	if err != nil {
 		t.Fatalf(`error occurred creating a new border client: %v`, err)
 	}
@@ -38,22 +38,22 @@ func TestHttpBorderClient_Update(t *testing.T) {
 		t.Fatalf(`error occurred deleting the nginx+ upstream server: %v`, err)
 	}
 
-	if !nginxClient.CalledFunctions["UpdateHTTPServers"] {
-		t.Fatalf(`expected UpdateHTTPServers to be called`)
+	if !nginxClient.CalledFunctions["UpdateStreamServers"] {
+		t.Fatalf(`expected UpdateStreamServers to be called`)
 	}
 }
 
-func TestHttpBorderClient_BadNginxClient(t *testing.T) {
+func TestTcpBorderClient_BadNginxClient(t *testing.T) {
 	var emptyInterface interface{}
-	_, err := NewBorderClient(ClientTypeHttp, emptyInterface)
+	_, err := NewBorderClient(ClientTypeNginxStream, emptyInterface)
 	if err == nil {
 		t.Fatalf(`expected an error to occur when creating a new border client`)
 	}
 }
 
-func TestHttpBorderClient_DeleteReturnsError(t *testing.T) {
-	event := buildServerUpdateEvent(deletedEventType, ClientTypeHttp)
-	borderClient, _, err := buildTerrorizingBorderClient(ClientTypeHttp)
+func TestTcpBorderClient_DeleteReturnsError(t *testing.T) {
+	event := buildServerUpdateEvent(deletedEventType, ClientTypeNginxStream)
+	borderClient, _, err := buildTerrorizingBorderClient(ClientTypeNginxStream)
 	if err != nil {
 		t.Fatalf(`error occurred creating a new border client: %v`, err)
 	}
@@ -65,9 +65,9 @@ func TestHttpBorderClient_DeleteReturnsError(t *testing.T) {
 	}
 }
 
-func TestHttpBorderClient_UpdateReturnsError(t *testing.T) {
-	event := buildServerUpdateEvent(createEventType, ClientTypeHttp)
-	borderClient, _, err := buildTerrorizingBorderClient(ClientTypeHttp)
+func TestTcpBorderClient_UpdateReturnsError(t *testing.T) {
+	event := buildServerUpdateEvent(createEventType, ClientTypeNginxStream)
+	borderClient, _, err := buildTerrorizingBorderClient(ClientTypeNginxStream)
 	if err != nil {
 		t.Fatalf(`error occurred creating a new border client: %v`, err)
 	}

--- a/internal/translation/translator.go
+++ b/internal/translation/translator.go
@@ -89,7 +89,7 @@ func fixIngressName(name string) string {
 	return name[4:]
 }
 
-// getClientType returns the client type for the port, defaults to ClientTypeHttp if no Annotation is found.
+// getClientType returns the client type for the port, defaults to ClientTypeNginxHttp if no Annotation is found.
 func getClientType(portName string, annotations map[string]string) string {
 	key := fmt.Sprintf("%s/%s", configuration.PortAnnotationPrefix, portName)
 	logrus.Infof("getClientType: key=%s", key)
@@ -99,5 +99,5 @@ func getClientType(portName string, annotations map[string]string) string {
 		}
 	}
 
-	return application.ClientTypeHttp
+	return application.ClientTypeNginxHttp
 }


### PR DESCRIPTION
### Proposed changes

Closes #47 
See Issue #47, this renames terms to be in line with their NGINX counterparts.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [X] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-k8s-loadbalancer/blob/main/CONTRIBUTING.md) document
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] If applicable, I have checked that any relevant tests pass after adding my changes
- [X] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-k8s-loadbalancer/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-k8s-loadbalancer/blob/main/CHANGELOG.md))
